### PR TITLE
Critical fix

### DIFF
--- a/src/Event/EventHandler.php
+++ b/src/Event/EventHandler.php
@@ -65,7 +65,7 @@ class EventHandler implements EventInterface
 
         //do the obvious match
         if (isset($this->observers[$event])) {
-            $matches[] = array(
+            $matches[$event] = array(
                 'event' => $event,
                 'pattern' => $event,
                 'variables' => array()
@@ -84,7 +84,7 @@ class EventHandler implements EventInterface
                     array_shift($variables);
                 }
 
-                $matches[] = array(
+                $matches[$pattern] = array(
                     'event' => $event,
                     'pattern' => $pattern,
                     'variables' => $variables
@@ -92,7 +92,7 @@ class EventHandler implements EventInterface
             }
         }
 
-        return $matches;
+        return array_values($matches);
     }
 
     /**

--- a/src/Framework/App.php
+++ b/src/Framework/App.php
@@ -300,12 +300,14 @@ class App
      */
     public function route($method, $path, $callback, ...$args)
     {
-        //if no args
-        if (empty($args)) {
+        array_unshift($args, $callback);
+
+        foreach ($args as $callback) {
             //if it's a string
             if (is_string($callback)) {
                 //it's an event
                 $event = $callback;
+                //make into callback
                 $callback = function ($request, $response) use ($event) {
                     $this->trigger($event, $request, $response);
                 };
@@ -322,21 +324,7 @@ class App
                 //route it
                 $this->routeHttp($method, $path, $callback);
             }
-
-            return $this;
         }
-
-        //we are going to make a flow
-        $event = $method . ' ' . $path;
-
-        //which is now an event driven route
-        $this->flow($event, $callback, ...$args);
-
-        $callback = function ($request, $response) use ($event) {
-            $this->trigger($event, $request, $response);
-        };
-
-        $this->routeHttp($method, $path, $this->bindCallback($callback));
 
         return $this;
     }


### PR DESCRIPTION
 - simpler logic for app routing 
- Critical fix: 2 events with the same regex was calling twice